### PR TITLE
Upgrade activesupport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage/
 .env.*
 !.env.example
 !.env.travis
+.ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    orcid_client (0.10.1)
+    orcid_client (0.11.0)
       activesupport (>= 6, < 7)
       bolognese (~> 2.1.0)
       builder (~> 3.2, >= 3.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     orcid_client (0.10.1)
-      activesupport (>= 4.2.5, < 6)
+      activesupport (>= 6, < 7)
       bolognese (~> 2.1.0)
       builder (~> 3.2, >= 3.2.2)
       dotenv (~> 2.1, >= 2.1.1)
@@ -13,11 +13,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.8.1)
+    activesupport (6.1.7.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     amazing_print (1.4.0)
@@ -55,7 +56,7 @@ GEM
       citeproc (~> 1.0, >= 1.0.9)
       csl (~> 1.6)
     colorize (0.8.1)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.3)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -100,7 +101,7 @@ GEM
       tilt
     hashdiff (1.0.1)
     htmlentities (4.3.4)
-    i18n (1.12.0)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     iso8601 (0.9.1)
     json-canonicalization (0.3.0)
@@ -137,7 +138,7 @@ GEM
       oj (>= 2.8.3)
       oj_mimic_json (~> 1.0, >= 1.0.1)
     matrix (0.4.2)
-    minitest (5.16.3)
+    minitest (5.22.3)
     multi_json (1.15.0)
     multipart-post (2.2.3)
     namae (1.0.2)
@@ -207,10 +208,9 @@ GEM
       rdf (~> 3.2)
     temple (0.9.1)
     thor (1.2.1)
-    thread_safe (0.3.6)
     tilt (2.0.11)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-types (1.8.0)
     unicode_utils (1.4.0)
     vcr (6.1.0)
@@ -218,6 +218,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.6.13)
     zlib (2.1.1)
 
 PLATFORMS

--- a/lib/orcid_client/version.rb
+++ b/lib/orcid_client/version.rb
@@ -1,3 +1,3 @@
 module OrcidClient
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 end

--- a/orcid_client.gemspec
+++ b/orcid_client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Declary dependencies here, rather than in the Gemfile
-  s.add_dependency 'activesupport', '>= 4.2.5', '< 6'
+  s.add_dependency 'activesupport', '>= 6', '< 7'
   s.add_dependency 'bolognese', '~> 2.1.0'
   s.add_dependency 'builder', '~> 3.2', '>= 3.2.2'
   s.add_dependency 'dotenv', '~> 2.1', '>= 2.1.1'


### PR DESCRIPTION
## Purpose
To support Rails 6, this gem which is used by volpino needs to support a newer version of ActiveSupport.

So this is just an upgrade to active support, not all gems as other gems require further compatability changes.
This is stage 1 and we can always Upgrade to Ruby 3 and use newer bolognese/maremma later.

## Approach
Gem upgrade

#### Open Questions and Pre-Merge TODOs
N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
